### PR TITLE
fix: `CENT` -> `MILL`

### DIFF
--- a/privacy.md
+++ b/privacy.md
@@ -193,12 +193,12 @@ You can increase the quota on your account by making a payment to the [`OdisPaym
 if (remainingQuota < 1) {
   const stableTokenContract = await kit.contracts.getStableToken();
   const odisPaymentsContract = await kit.contracts.getOdisPayments();
-  const ONE_CENT_CUSD_WEI = 10000000000000000
+  const ONE_MILL_CUSD_WEI = 10000000000000000
   await stableTokenContract
-    .increaseAllowance(odisPaymentsContract.address, ONE_CENT_CUSD_WEI)
+    .increaseAllowance(odisPaymentsContract.address, ONE_MILL_CUSD_WEI)
     .sendAndWaitForReceipt();
   const odisPayment = await odisPaymentsContract
-    .payInCUSD(this.issuer.address, ONE_CENT_CUSD_WEI)
+    .payInCUSD(this.issuer.address, ONE_MILL_CUSD_WEI)
     .sendAndWaitForReceipt();
 }
 ```


### PR DESCRIPTION
Changing Cent to Mill.

According to Wikipedia, 

> The mill (American English) or mil (Commonwealth English, except Canada) is a unit of currency (sometimes symbolized as ₥), used in several countries as one-thousandth of the base unit